### PR TITLE
Fix code quality warnings from CodeQL, Roslyn, and SonarQube

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -16,3 +16,13 @@ query-filters:
       id: cs/path-combine
     paths:
       - src/DemaConsulting.FileAssert/PathHelpers.cs
+  # Exclude useless-assignment warnings in generated code under obj/ directories
+  - exclude:
+      id: cs/useless-assignment-to-local
+    paths:
+      - "**/obj/**"
+  # Exclude missed-ternary-operator warnings in generated code under obj/ directories
+  - exclude:
+      id: cs/missed-ternary-operator
+    paths:
+      - "**/obj/**"

--- a/src/DemaConsulting.FileAssert/Modeling/FileAssertFile.cs
+++ b/src/DemaConsulting.FileAssert/Modeling/FileAssertFile.cs
@@ -239,34 +239,45 @@ internal sealed class FileAssertFile
         {
             foreach (var entryPath in files)
             {
-                // Enforce size constraints when specified
-                if (MinSize.HasValue || MaxSize.HasValue)
-                {
-                    var size = container.GetEntrySize(entryPath);
-                    var displayPath = container.GetDisplayPath(entryPath);
-
-                    if (MinSize.HasValue && size < MinSize.Value)
-                    {
-                        context.WriteError(
-                            $"File '{displayPath}' is {size} byte(s), which is less than the minimum {MinSize.Value} bytes");
-                    }
-
-                    if (MaxSize.HasValue && size > MaxSize.Value)
-                    {
-                        context.WriteError(
-                            $"File '{displayPath}' is {size} byte(s), which exceeds the maximum {MaxSize.Value} bytes");
-                    }
-                }
-
-                // Delegate to each file-type assert unit when declared
-                TextAssert?.Run(context, container, entryPath);
-                PdfAssert?.Run(context, container, entryPath);
-                XmlAssert?.Run(context, container, entryPath);
-                HtmlAssert?.Run(context, container, entryPath);
-                YamlAssert?.Run(context, container, entryPath);
-                JsonAssert?.Run(context, container, entryPath);
-                ZipAssert?.Run(context, container, entryPath);
+                RunEntryChecks(context, container, entryPath);
             }
         }
+    }
+
+    /// <summary>
+    ///     Runs size and file-type assertions for a single matched entry, reporting violations.
+    /// </summary>
+    /// <param name="context">The context used for reporting errors.</param>
+    /// <param name="container">The container that holds the entry.</param>
+    /// <param name="entryPath">The relative path of the entry within the container.</param>
+    private void RunEntryChecks(IContext context, IFileContainer container, string entryPath)
+    {
+        // Enforce size constraints when specified
+        if (MinSize.HasValue || MaxSize.HasValue)
+        {
+            var size = container.GetEntrySize(entryPath);
+            var displayPath = container.GetDisplayPath(entryPath);
+
+            if (MinSize.HasValue && size < MinSize.Value)
+            {
+                context.WriteError(
+                    $"File '{displayPath}' is {size} byte(s), which is less than the minimum {MinSize.Value} bytes");
+            }
+
+            if (MaxSize.HasValue && size > MaxSize.Value)
+            {
+                context.WriteError(
+                    $"File '{displayPath}' is {size} byte(s), which exceeds the maximum {MaxSize.Value} bytes");
+            }
+        }
+
+        // Delegate to each file-type assert unit when declared
+        TextAssert?.Run(context, container, entryPath);
+        PdfAssert?.Run(context, container, entryPath);
+        XmlAssert?.Run(context, container, entryPath);
+        HtmlAssert?.Run(context, container, entryPath);
+        YamlAssert?.Run(context, container, entryPath);
+        JsonAssert?.Run(context, container, entryPath);
+        ZipAssert?.Run(context, container, entryPath);
     }
 }

--- a/src/DemaConsulting.FileAssert/Modeling/FileAssertPdfAssert.cs
+++ b/src/DemaConsulting.FileAssert/Modeling/FileAssertPdfAssert.cs
@@ -24,6 +24,7 @@ using DemaConsulting.FileAssert.Cli;
 using DemaConsulting.FileAssert.Configuration;
 using DemaConsulting.FileAssert.Utilities;
 using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
 
 namespace DemaConsulting.FileAssert.Modeling;
 
@@ -275,43 +276,69 @@ internal sealed class FileAssertPdfAssert
 
         using (document)
         {
-            // Apply metadata assertions to the document information
-            foreach (var rule in _metadata)
-            {
-                var value = GetMetadataField(document, rule.Field);
-                rule.Apply(context, displayPath, value);
-            }
-
-            // Apply page count constraints and collect pages only when needed
-            if (_pages != null || _text.Count > 0)
-            {
-                var pageList = document.GetPages().ToList();
-                _pages?.Apply(context, displayPath, pageList.Count);
-
-                // Apply text rules to the extracted body text when rules are defined
-                if (_text.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    for (var i = 0; i < pageList.Count; i++)
-                    {
-                        if (i > 0)
-                        {
-                            // Separate page text with newlines so that text rules don't
-                            // see two adjacent words from different pages glued together.
-                            sb.Append('\n');
-                        }
-
-                        sb.Append(pageList[i].Text);
-                    }
-
-                    var content = sb.ToString();
-                    foreach (var rule in _text)
-                    {
-                        rule.Apply(context, displayPath, content);
-                    }
-                }
-            }
+            RunDocumentAssertions(context, displayPath, document);
         }
+    }
+
+    /// <summary>
+    ///     Applies all configured metadata, page-count, and text assertions to an already-opened
+    ///     PDF document, reporting violations via <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The context used for reporting errors.</param>
+    /// <param name="displayPath">The display path of the file, used in error messages.</param>
+    /// <param name="document">The opened PDF document to assert against.</param>
+    private void RunDocumentAssertions(IContext context, string displayPath, PdfDocument document)
+    {
+        // Apply metadata assertions to the document information
+        foreach (var rule in _metadata)
+        {
+            var value = GetMetadataField(document, rule.Field);
+            rule.Apply(context, displayPath, value);
+        }
+
+        // Skip page and text checks when no such constraints are configured
+        if (_pages == null && _text.Count == 0)
+        {
+            return;
+        }
+
+        // Apply page count constraints and collect pages only when needed
+        var pageList = document.GetPages().ToList();
+        _pages?.Apply(context, displayPath, pageList.Count);
+
+        // Apply text rules to the extracted body text when rules are defined
+        if (_text.Count == 0)
+        {
+            return;
+        }
+
+        var content = BuildPageText(pageList);
+        foreach (var rule in _text)
+        {
+            rule.Apply(context, displayPath, content);
+        }
+    }
+
+    /// <summary>
+    ///     Concatenates the text from all pages into a single string, separating pages with newlines
+    ///     so that text rules do not see words from adjacent pages merged together.
+    /// </summary>
+    /// <param name="pages">The ordered list of pages from the PDF document.</param>
+    /// <returns>A single string containing all page text joined with newline separators.</returns>
+    private static string BuildPageText(IReadOnlyList<Page> pages)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < pages.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('\n');
+            }
+
+            sb.Append(pages[i].Text);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/DemaConsulting.FileAssert/Modeling/FileAssertPdfAssert.cs
+++ b/src/DemaConsulting.FileAssert/Modeling/FileAssertPdfAssert.cs
@@ -302,20 +302,21 @@ internal sealed class FileAssertPdfAssert
             return;
         }
 
-        // Apply page count constraints and collect pages only when needed
-        var pageList = document.GetPages().ToList();
-        _pages?.Apply(context, displayPath, pageList.Count);
-
-        // Apply text rules to the extracted body text when rules are defined
-        if (_text.Count == 0)
+        // When text rules are present, materialize pages once for both count and content.
+        // When only a page-count constraint is configured, enumerate without allocating Page objects.
+        if (_text.Count > 0)
         {
-            return;
+            var pageList = document.GetPages().ToList();
+            _pages?.Apply(context, displayPath, pageList.Count);
+            var content = BuildPageText(pageList);
+            foreach (var rule in _text)
+            {
+                rule.Apply(context, displayPath, content);
+            }
         }
-
-        var content = BuildPageText(pageList);
-        foreach (var rule in _text)
+        else
         {
-            rule.Apply(context, displayPath, content);
+            _pages?.Apply(context, displayPath, document.GetPages().Count());
         }
     }
 

--- a/test/DemaConsulting.FileAssert.Tests/Cli/CliTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/Cli/CliTests.cs
@@ -40,21 +40,20 @@ public class CliTests
         var logPath = tempDir.GetFilePath("out.log");
 
         // Act - create a context with the silent, validate, and log flags
-        using (var context = Context.Create(
+        using var context = Context.Create(
         [
             "--silent",
             "--validate",
             "--log", logPath
-        ]))
-        {
-            // Assert - all flags are reflected in the context properties
-            Assert.True(context.Silent);
-            Assert.True(context.Validate);
-            Assert.False(context.Version);
-            Assert.False(context.Help);
-            Assert.Equal(".fileassert.yaml", context.ConfigFile);
-            Assert.Equal(0, context.ExitCode);
-        }
+        ]);
+
+        // Assert - all flags are reflected in the context properties
+        Assert.True(context.Silent);
+        Assert.True(context.Validate);
+        Assert.False(context.Version);
+        Assert.False(context.Help);
+        Assert.Equal(".fileassert.yaml", context.ConfigFile);
+        Assert.Equal(0, context.ExitCode);
 
     }
 
@@ -137,8 +136,8 @@ public class CliTests
         // Arrange
         var originalOut = Console.Out;
         var originalError = Console.Error;
-        var outWriter = new System.IO.StringWriter();
-        var errorWriter = new System.IO.StringWriter();
+        using var outWriter = new System.IO.StringWriter();
+        using var errorWriter = new System.IO.StringWriter();
 
         try
         {

--- a/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertHtmlAssertTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertHtmlAssertTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.ObjectModel;
 using DemaConsulting.FileAssert.Cli;
 using DemaConsulting.FileAssert.Configuration;
 using DemaConsulting.FileAssert.Modeling;
@@ -471,7 +472,7 @@ public sealed class FileAssertHtmlAssertTests
         private readonly List<string> _errors = [];
 
         /// <summary>Gets all error messages captured since this context was created.</summary>
-        public IReadOnlyList<string> Errors => _errors.AsReadOnly();
+        public ReadOnlyCollection<string> Errors => _errors.AsReadOnly();
 
         /// <inheritdoc/>
         public void WriteLine(string message) { }

--- a/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertJsonAssertTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertJsonAssertTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.ObjectModel;
 using DemaConsulting.FileAssert.Cli;
 using DemaConsulting.FileAssert.Configuration;
 using DemaConsulting.FileAssert.Modeling;
@@ -400,7 +401,7 @@ public sealed class FileAssertJsonAssertTests
         private readonly List<string> _errors = [];
 
         /// <summary>Gets all error messages captured since this context was created.</summary>
-        public IReadOnlyList<string> Errors => _errors.AsReadOnly();
+        public ReadOnlyCollection<string> Errors => _errors.AsReadOnly();
 
         /// <inheritdoc/>
         public void WriteLine(string message) { }

--- a/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertYamlAssertTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertYamlAssertTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.ObjectModel;
 using DemaConsulting.FileAssert.Cli;
 using DemaConsulting.FileAssert.Configuration;
 using DemaConsulting.FileAssert.Modeling;
@@ -454,7 +455,7 @@ public sealed class FileAssertYamlAssertTests
         private readonly List<string> _errors = [];
 
         /// <summary>Gets all error messages captured since this context was created.</summary>
-        public IReadOnlyList<string> Errors => _errors.AsReadOnly();
+        public ReadOnlyCollection<string> Errors => _errors.AsReadOnly();
 
         /// <inheritdoc/>
         public void WriteLine(string message) { }

--- a/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertZipAssertTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/Modeling/FileAssertZipAssertTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.ObjectModel;
 using System.IO.Compression;
 using DemaConsulting.FileAssert.Cli;
 using DemaConsulting.FileAssert.Configuration;
@@ -83,8 +84,7 @@ public sealed class FileAssertZipAssertTests
         using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
         foreach (var entry in entries)
         {
-            var archiveEntry = archive.CreateEntry(entry);
-            using var stream = archiveEntry.Open();
+            using var stream = archive.CreateEntry(entry).Open();
 
             // Write a single placeholder byte so the entry is not an empty-stream edge case
             stream.WriteByte(0x00);
@@ -184,7 +184,7 @@ public sealed class FileAssertZipAssertTests
         private readonly List<string> _errors = [];
 
         /// <summary>Gets all error messages captured since this context was created.</summary>
-        public IReadOnlyList<string> Errors => _errors.AsReadOnly();
+        public ReadOnlyCollection<string> Errors => _errors.AsReadOnly();
 
         /// <inheritdoc/>
         public void WriteLine(string message) { }

--- a/test/DemaConsulting.FileAssert.Tests/ProgramTests.cs
+++ b/test/DemaConsulting.FileAssert.Tests/ProgramTests.cs
@@ -203,7 +203,7 @@ public class ProgramTests
             Program.Run(context);
 
             // Assert
-            var combined = outWriter.ToString() + errWriter.ToString();
+            var combined = $"{outWriter}{errWriter}";
             Assert.Contains("Configuration file not found", combined);
             Assert.Equal(1, context.ExitCode);
         }


### PR DESCRIPTION
- Add CodeQL exclusions for cs/useless-assignment-to-local and cs/missed-ternary-operator targeting generated obj/ files
- Inline archiveEntry variable in ZipAssertTests to fix cs/linq/missed-select
- Use string interpolation in ProgramTests to fix cs/useless-tostring-call
- Add using var to StringWriter locals in CliTests to fix cs/local-not-disposed
- Simplify using statement block to using var in CliTests (IDE0063)
- Change Errors property return type to ReadOnlyCollection<string> in four CapturingContext test helpers (CA1859)
- Extract RunDocumentAssertions and BuildPageText helpers from FileAssertPdfAssert.Run to reduce cognitive complexity (S3776)
- Extract RunEntryChecks helper from FileAssertFile.Run to reduce cognitive complexity (S3776)